### PR TITLE
cratesio: support for Targets in rust cargo

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func main() {
 			}
 			return nil
 		},
-
 		Action: mainFunc,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{

--- a/pkg/cratesio/cargo.go
+++ b/pkg/cratesio/cargo.go
@@ -9,6 +9,7 @@ import (
 )
 
 // https://doc.rust-lang.org/cargo/reference/manifest.html
+// https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
 
 // Name for identifying this language support
 const Name = "crates.io (Rust)"
@@ -16,7 +17,14 @@ const Name = "crates.io (Rust)"
 // Cargo is a representation of a `Cargo.toml`.
 // This is bare-bones enough to gather the names of the dependencies
 type Cargo struct {
-	Package      Package                `toml:"package"`
+	Package           Package                `toml:"package"`
+	Dependencies      map[string]interface{} `toml:"dependencies"`
+	BuildDependencies map[string]interface{} `toml:"dev-dependencies"`
+	DevDependencies   map[string]interface{} `toml:"build-dependencies"`
+	Target            map[string]Target      `toml:"target"`
+}
+
+type Target struct {
 	Dependencies map[string]interface{} `toml:"dependencies"`
 }
 

--- a/pkg/cratesio/cargo_test.go
+++ b/pkg/cratesio/cargo_test.go
@@ -19,6 +19,7 @@ func TestCargoLoad(t *testing.T) {
 		"hard-xml":    0,
 		"uuid":        0,
 		"examplename": 0,
+		"regex":       0,
 	}
 	for k := range c.Dependencies {
 		_, ok := expected[k]

--- a/pkg/cratesio/check.go
+++ b/pkg/cratesio/check.go
@@ -1,6 +1,7 @@
 package cratesio
 
 import (
+	"encoding/json"
 	"fmt"
 	urlpkg "net/url"
 	"strings"
@@ -25,13 +26,19 @@ func ToCheckCargo(c *Cargo) ([]check.Check, error) {
 		}
 	}
 
-	for dep := range c.Dependencies {
+	for dep, val := range c.Dependencies {
+		dd, err := getDepData(val)
+		if err != nil {
+			logrus.Infof("%q value was not parsed correctly (%#v): %s", dep, val, err)
+			continue
+		}
+		logrus.Debugf("%q value: %#v", dep, dd)
 		s, err := FetchSingle(dep)
 		if err != nil {
 			return toCheck, fmt.Errorf("failed fetching %q: %w", dep, err)
 		}
 		if !strings.EqualFold(s.Crate.ID, dep) {
-			logrus.Infof("%q does not match %q", s.Crate.ID, dep)
+			logrus.Infof("%q does not match %q. Skipping.", s.Crate.ID, dep)
 			continue
 		}
 		if s.Crate.Repository == "" {
@@ -50,6 +57,40 @@ func ToCheckCargo(c *Cargo) ([]check.Check, error) {
 		})
 	}
 
+	for target, t := range c.Target {
+		logrus.Debugf("reviewing deps of %s: %#v", target, t)
+		for dep, val := range t.Dependencies {
+			dd, err := getDepData(dep)
+			if err != nil {
+				logrus.Infof("%q value was not parsed correctly (%#v): %s", dep, val, err)
+				continue
+			}
+			logrus.Debugf("%q value: %#v", dep, dd)
+			s, err := FetchSingle(dep)
+			if err != nil {
+				return toCheck, fmt.Errorf("failed fetching %q: %w", dep, err)
+			}
+			if !strings.EqualFold(s.Crate.ID, dep) {
+				logrus.Infof("%q does not match %q. Skipping.", s.Crate.ID, dep)
+				continue
+			}
+			if s.Crate.Repository == "" {
+				logrus.Infof("%q does not list a repository", s.Crate.ID)
+				continue
+			}
+			u, err := urlpkg.Parse(s.Crate.Repository)
+			if err != nil {
+				logrus.Infof("%q did not parse correctly", s.Crate.Repository)
+				continue
+			}
+			toCheck = append(toCheck, check.Check{
+				Lang:    Name,
+				PkgName: dep,
+				VcsUrl:  u,
+			})
+		}
+	}
+
 	return toCheck, nil
 }
 
@@ -62,7 +103,7 @@ func ToCheckCargoLock(cl *CargoLock) ([]check.Check, error) {
 			return toCheck, fmt.Errorf("failed fetching %q: %w", pkg, err)
 		}
 		if !strings.EqualFold(s.Crate.ID, pkg.Name) {
-			logrus.Infof("%q does not match %q", s.Crate.ID, pkg.Name)
+			logrus.Infof("%q does not match %q. Skipping.", s.Crate.ID, pkg.Name)
 			continue
 		}
 		if s.Crate.Repository == "" {
@@ -91,4 +132,52 @@ func ToCheckCargoLock(cl *CargoLock) ([]check.Check, error) {
 	}
 
 	return toCheck, nil
+}
+
+/*
+this is a bit gross due to the flexibility of toml ...
+```toml
+[dependencies]
+hello_utils = "0.1.0"
+smallvec = { git = "https://github.com/servo/rust-smallvec.git", version = "1.0" }
+bitflags = { path = "my-bitflags", version = "1.0" }
+```
+*/
+func getDepData(d interface{}) (*depData, error) {
+	// "1.2.0"
+	s, ok := d.(string)
+	if ok {
+		return &depData{Version: s}, nil
+	}
+	// 1.0
+	f, ok := d.(float64)
+	if ok {
+		return &depData{Version: fmt.Sprintf("%f", f)}, nil
+	}
+	// 1
+	i, ok := d.(int64)
+	if ok {
+		return &depData{Version: fmt.Sprintf("%d", i)}, nil
+	}
+
+	buf, err := json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	dd := depData{}
+	err = json.Unmarshal(buf, &dd)
+	if err != nil {
+		return nil, err
+	}
+	return &dd, nil
+}
+
+type depData struct {
+	Version  string   `json:"version,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Git      string   `json:"git,omitempty"`
+	Optional bool     `json:"optional,omitempty"`
+	Registry string   `json:"registry,omitempty"`
+	Package  string   `json:"package,omitempty"`
+	Features []string `json:"features,omitempty"`
 }

--- a/pkg/cratesio/testdata/Cargo.toml
+++ b/pkg/cratesio/testdata/Cargo.toml
@@ -5,11 +5,30 @@ edition = "2021"
 
 # sample comment
 
+[build-dependencies]
+youins = "0.11"
+
+[dev-dependencies]
+yins = "0.11"
+
 [dependencies]
 yall = "0.11"
 tokio = { version = "1", features = ["full"] }
 hard-xml = "1.15.0"
 uuid = "1.2"
+regex = { git = "https://github.com/rust-lang/regex.git", branch = "next" }
 
 [dependencies.examplename]
 path = "examplename"
+
+[target.'cfg(windows)'.dependencies]
+winhttp = "0.4.0"
+
+[target.'cfg(unix)'.dependencies]
+openssl = "1.0.1"
+
+[target.'cfg(target_arch = "x86")'.dependencies]
+native-i686 = { path = "native/i686" }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+native-x86_64 = { path = "native/x86_64" }


### PR DESCRIPTION
Now Cargo.toml with "Target" sections can have their deps checked.