### PR TITLE
packager/repoer: adding interfaces for languages and source servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.swp
+is-archived
+Session.vim

--- a/pkg/check/common.go
+++ b/pkg/check/common.go
@@ -4,6 +4,8 @@ import (
 	urlpkg "net/url"
 )
 
+// Check is the unit of work to be evaulated, as well as the result of whether
+// a package has been archived.
 type Check struct {
 	Lang     string
 	PkgName  string

--- a/pkg/cratesio/cargo.go
+++ b/pkg/cratesio/cargo.go
@@ -1,18 +1,64 @@
 package cratesio
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/sirupsen/logrus"
+	"github.com/vbatts/is-archived/pkg/check"
+	"github.com/vbatts/is-archived/pkg/types"
 )
 
 // https://doc.rust-lang.org/cargo/reference/manifest.html
 // https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
 
-// Name for identifying this language support
-const Name = "crates.io (Rust)"
+const (
+	// Name for identifying this language support
+	Name = "crates.io (Rust)"
+
+	CargoFile     = "Cargo.toml"
+	CargoLockFile = "Cargo.lock"
+)
+
+func init() {
+	if err := types.RegisterPackager(cargoPackager{fileType: CargoFile}); err != nil {
+		logrus.Errorf("failed to register Packager for %q", CargoFile)
+	}
+	if err := types.RegisterPackager(cargoPackager{fileType: CargoLockFile}); err != nil {
+		logrus.Errorf("failed to register Packager for %q", CargoLockFile)
+	}
+}
+
+type cargoPackager struct {
+	fileType string
+}
+
+func (cp cargoPackager) Name() string {
+	return fmt.Sprintf("%s - %s", Name, cp.fileType)
+}
+
+func (cp cargoPackager) FileType() string {
+	return cp.fileType
+}
+
+func (cp cargoPackager) LoadFile(filename string) ([]check.Check, error) {
+	if cp.fileType == CargoLockFile {
+		clf, err := LoadCargoLockFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		return ToCheckCargoLock(clf)
+	}
+
+	cf, err := LoadCargoFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return ToCheckCargo(cf)
+}
 
 // Cargo is a representation of a `Cargo.toml`.
 // This is bare-bones enough to gather the names of the dependencies

--- a/pkg/golang/mod.go
+++ b/pkg/golang/mod.go
@@ -10,10 +10,40 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/is-archived/pkg/check"
+	"github.com/vbatts/is-archived/pkg/types"
 	"github.com/vbatts/is-archived/pkg/vcs"
 )
 
-const Name = "go.mod (golang)"
+const (
+	Name      = "go.mod (golang)"
+	GoModFile = "go.mod"
+)
+
+func init() {
+	if err := types.RegisterPackager(goPackager{fileType: GoModFile}); err != nil {
+		logrus.Errorf("failed to register Packager for %q", GoModFile)
+	}
+}
+
+type goPackager struct {
+	fileType string
+}
+
+func (gp goPackager) Name() string {
+	return Name
+}
+
+func (gp goPackager) FileType() string {
+	return gp.fileType
+}
+
+func (gp goPackager) LoadFile(filename string) ([]check.Check, error) {
+	gmf, err := LoadGoModFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return ToCheck(gmf)
+}
 
 func LoadGoModFile(fpath string) (*Mod, error) {
 	cmd := exec.Command("go", "mod", "edit", "-json")

--- a/pkg/types/packager.go
+++ b/pkg/types/packager.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/vbatts/is-archived/pkg/check"
+)
+
+type Packager interface {
+	Name() string
+	FileType() string
+	LoadFile(string) ([]check.Check, error)
+}
+
+var packagers = map[string]Packager{}
+
+func RegisterPackager(p Packager) error {
+	if p.FileType() == "" {
+		return fmt.Errorf("no FileType")
+	}
+	packagers[p.FileType()] = p
+
+	return nil
+}
+
+func PackagerFileTypes() []string {
+	ft := []string{}
+	for key := range packagers {
+		ft = append(ft, key)
+	}
+	return ft
+}
+
+func GetPackager(filetype string) (Packager, error) {
+	if val, ok := packagers[filetype]; ok {
+		return val, nil
+	}
+	return nil, fmt.Errorf("no packager for %q found", filetype)
+}

--- a/pkg/types/repoer.go
+++ b/pkg/types/repoer.go
@@ -1,0 +1,14 @@
+package types
+
+import "github.com/vbatts/is-archived/pkg/check"
+
+type Repoer interface {
+	// Run will evaluate whether the package is archive only if the repository is hosted on that Repoer's domain i.e. github.com, codeberg.org, etc
+	Run(*check.Check)
+}
+
+var repoers = []Repoer{}
+
+func RegisterRepoer(r Repoer) {
+	repoers = append(repoers, r)
+}


### PR DESCRIPTION
This makes an interface that any "Packager" or "Repoer" can satisfy, and then just compile into `main.go` rather than changing the case statement inside `main()`.

The stub for `Repoer` is there, but not plumbed in for github yet. Only `Packager` for golang and rust are plumbed in so far.