### PR TITLE
repoer: basically working, but an issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
 	"github.com/vbatts/is-archived/pkg/check"
 	_ "github.com/vbatts/is-archived/pkg/cratesio"
-	"github.com/vbatts/is-archived/pkg/gh"
+	_ "github.com/vbatts/is-archived/pkg/gh"
 	_ "github.com/vbatts/is-archived/pkg/golang"
 	_ "github.com/vbatts/is-archived/pkg/npm"
 	_ "github.com/vbatts/is-archived/pkg/pypi"
@@ -49,7 +47,6 @@ func main() {
 }
 
 func mainFunc(c *cli.Context) error {
-	ctx := context.Background()
 
 	/* Maybe make 'go' and 'rust' subcommands to use this
 	fi, _ := os.Stdin.Stat()
@@ -81,30 +78,29 @@ func mainFunc(c *cli.Context) error {
 			toCheck = append(toCheck, checks...)
 		}
 	}
+	if _, err := os.Stat("Gemfile"); err == nil {
+		logrus.Error("ruby Gemfile not implemented yet")
+	}
 	if !foundPackagers {
 		logrus.Fatal("no known packager filetypes found!")
 	}
 
-	if _, err := os.Stat("Gemfile"); err == nil {
-		logrus.Error("ruby Gemfile not implemented yet")
-	}
+	// XXX ok let's see, we'll have a list of all repos "toCheck", and they have
+	// already been only added to the list if the RepoerDomains() shows the
+	// domain as supported.
+	// From this we could either extract and group the checks by domain,
+	// or just iterate through the checks, needing a way to run the appropriate
+	// check for the domain...
 
-	client := gh.New(ctx, os.Getenv("GITHUB_TOKEN"))
-
-	logrus.Infof("checking %d github projects ...", len(toCheck))
-	for _, check := range toCheck {
-		if !strings.HasPrefix(check.VcsUrl.Host, "github.com") {
-			continue
-		}
-		org, repo := gh.OrgRepoFromURL(check.VcsUrl)
-		isArchived, err := client.IsRepoArchived(org, repo)
+	//logrus.Infof("checking %d github projects ...", len(toCheck))
+	for _, ck := range toCheck {
+		err := types.RepoerRun(&ck)
 		if err != nil {
 			logrus.Error(err)
 			continue
 		}
-		if isArchived {
-			check.Archived = true
-			fmt.Printf("%q is archived (%s)\n", check.PkgName, check.VcsUrl.String())
+		if ck.Archived {
+			fmt.Printf("%q is archived (%s)\n", ck.PkgName, ck.VcsUrl.String())
 		}
 	}
 	// TODO print a combined report

--- a/main.go
+++ b/main.go
@@ -94,9 +94,10 @@ func mainFunc(c *cli.Context) error {
 
 	//logrus.Infof("checking %d github projects ...", len(toCheck))
 	for _, ck := range toCheck {
+		logrus.Debugf("checking %q (%s)", ck.PkgName, ck.VcsUrl.String())
 		err := types.RepoerRun(&ck)
 		if err != nil {
-			logrus.Error(err)
+			logrus.Warnf("for %q: %s", ck.VcsUrl.String(), err)
 			continue
 		}
 		if ck.Archived {

--- a/pkg/gh/archived.go
+++ b/pkg/gh/archived.go
@@ -4,12 +4,43 @@ import (
 	"context"
 	"fmt"
 	urlpkg "net/url"
+	"os"
 	"strings"
 
 	"github.com/google/go-github/github"
+	"github.com/vbatts/is-archived/pkg/check"
+	"github.com/vbatts/is-archived/pkg/types"
 	"github.com/vbatts/is-archived/version"
 	"golang.org/x/oauth2"
 )
+
+const domain = "github.com"
+
+func init() {
+	types.RegisterRepoer(githubRepoer{
+		client: New(context.Background(), os.Getenv("GITHUB_TOKEN")),
+	})
+}
+
+type githubRepoer struct {
+	client Handler
+}
+
+func (r githubRepoer) Domain() string {
+	return domain
+}
+
+func (r githubRepoer) Run(ck *check.Check) error {
+	org, repo := OrgRepoFromURL(ck.VcsUrl)
+	isArchived, err := r.client.IsRepoArchived(org, repo)
+	if err != nil {
+		return err
+	}
+	if isArchived {
+		ck.Archived = true
+	}
+	return nil
+}
 
 type Handler struct {
 	ctx    context.Context

--- a/pkg/golang/mod.go
+++ b/pkg/golang/mod.go
@@ -76,36 +76,59 @@ type Import struct {
 	Indirect bool   `json:"Indirect"`
 }
 
+func inArray(str string, arr []string) bool {
+	for _, v := range arr {
+		if strings.EqualFold(str, v) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPrefixArray(str string, arr []string) bool {
+	for _, v := range arr {
+		if strings.HasPrefix(str, v) {
+			return true
+		}
+	}
+	return false
+}
+
 func ToCheck(m *Mod) ([]check.Check, error) {
 	// collect the list first
 	toCheck := []check.Check{}
+	rDomains := types.RepoerDomains()
 	for _, req := range m.Require {
-		// TODO this ought to iterate over Repoer's domains as the "known" domains to check.
-		if !strings.HasPrefix(req.Path, "github.com") {
+		if !hasPrefixArray(req.Path, rDomains) {
+			logrus.Debugf("[%s] inspecting possible meta path %q", Name, req.Path)
 			_, mi, err := vcs.MetaImportForPath(req.Path)
 			if err == nil { // ignoring this error as we'll just skip and continue ...
 				if len(mi) == 0 {
 					// we didn't get any meta imports from that import path
-					logrus.Debugf("skipping %q as it had no HTML Meta go-imports", req.Path)
+					logrus.Debugf("[%s] skipping %q as it had no HTML Meta go-imports", Name, req.Path)
 					continue
 				}
 				u, err := urlpkg.Parse(mi[0].RepoRoot)
 				if err != nil {
-					logrus.Infof("skipping %q as %q didn't parse well: %v", req.Path, mi[0].RepoRoot, err)
+					logrus.Infof("[%s] skipping %q as %q didn't parse well: %v", Name, req.Path, mi[0].RepoRoot, err)
 					continue
 				}
-				toCheck = append(toCheck, check.Check{
-					Lang:    Name,
-					PkgName: req.Path,
-					VcsUrl:  u,
-				})
+				if !inArray(u.Host, rDomains) {
+					logrus.Debugf("[%s] do not have a repo check for %q", Name, u.String())
+				} else {
+					toCheck = append(toCheck, check.Check{
+						Lang:    Name,
+						PkgName: req.Path,
+						VcsUrl:  u,
+					})
+				}
 			}
 			continue
 		}
 
 		u, err := urlpkg.Parse(fmt.Sprintf("https://%s", req.Path))
 		if err != nil {
-			logrus.Debugf("skipping %q as %q didn't parse well: %v", req.Path, fmt.Sprintf("https://%s", req.Path), err)
+			logrus.Debugf("[%s] skipping %q as %q didn't parse well: %v", Name, req.Path, fmt.Sprintf("https://%s", req.Path), err)
 			continue
 		}
 		toCheck = append(toCheck, check.Check{

--- a/pkg/pypi/check.go
+++ b/pkg/pypi/check.go
@@ -102,10 +102,11 @@ func ToCheck(reqs []string) ([]check.Check, error) {
 			if err != nil {
 				logrus.Errorf("[pypi] %q Error parsing URL %q", req, pkg.Info.HomePage)
 			} else {
-				// TODO iterate through the domains of the Repoers
-				if u.Host == "github.com" {
-					confidence = 1.0
-					check.VcsUrl = u
+				for _, domain := range types.RepoerDomains() {
+					if u.Host == domain {
+						confidence = 1.0
+						check.VcsUrl = u
+					}
 				}
 			}
 		}
@@ -122,9 +123,10 @@ func ToCheck(reqs []string) ([]check.Check, error) {
 						if err != nil {
 							logrus.Errorf("[pypi] %q Error parsing URL %q", req, v)
 						} else {
-							// TODO iterate through the domains of the Repoers
-							if u.Host == "github.com" {
-								check.VcsUrl = u
+							for _, domain := range types.RepoerDomains() {
+								if u.Host == domain {
+									check.VcsUrl = u
+								}
 							}
 						}
 					}

--- a/pkg/types/repoer.go
+++ b/pkg/types/repoer.go
@@ -1,14 +1,48 @@
 package types
 
-import "github.com/vbatts/is-archived/pkg/check"
+import (
+	"fmt"
+
+	"github.com/vbatts/is-archived/pkg/check"
+)
 
 type Repoer interface {
 	// Run will evaluate whether the package is archive only if the repository is hosted on that Repoer's domain i.e. github.com, codeberg.org, etc
-	Run(*check.Check)
+	Run(*check.Check) error
+
+	Domain() string
 }
 
 var repoers = []Repoer{}
 
 func RegisterRepoer(r Repoer) {
 	repoers = append(repoers, r)
+}
+
+func RepoerDomains() []string {
+	domains := []string{}
+	for _, r := range repoers {
+		domains = append(domains, r.Domain())
+	}
+	return domains
+}
+
+func RepoerRun(ck *check.Check) error {
+	if ck == nil || ck.VcsUrl == nil {
+		return fmt.Errorf("check and/or its URL is nil")
+	}
+	host := ck.VcsUrl.Host
+	found := false
+	for _, rp := range repoers {
+		if host != rp.Domain() {
+			continue
+		}
+		found = true
+
+		rp.Run(ck)
+	}
+	if !found {
+		return fmt.Errorf("no checks run for %q", ck.PkgName)
+	}
+	return nil
 }

--- a/pkg/types/repoer.go
+++ b/pkg/types/repoer.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vbatts/is-archived/pkg/check"
 )
 
@@ -39,7 +40,9 @@ func RepoerRun(ck *check.Check) error {
 		}
 		found = true
 
-		rp.Run(ck)
+		if err := rp.Run(ck); err != nil {
+			logrus.Warnf("when checking %q: %s", ck.PkgName, err)
+		}
 	}
 	if !found {
 		return fmt.Errorf("no checks run for %q", ck.PkgName)


### PR DESCRIPTION
I've just realized [again] that for some language types like golang, the source repo can hide in HTML meta redirects, so strictly looking at the domain name is not enough.
I'm not sure if all languages do this or only golang ...