### PR TITLE
Better support for gopkg.in based packages

### DIFF
--- a/pkg/vcs/discovery.go
+++ b/pkg/vcs/discovery.go
@@ -111,15 +111,28 @@ func parseMetaGoImports(r io.Reader, mod ModuleMode) ([]MetaImport, error) {
 		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
 			continue
 		}
-		if attrValue(e.Attr, "name") != "go-import" {
-			continue
-		}
-		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
-			imports = append(imports, MetaImport{
-				Prefix:   f[0],
-				VCS:      f[1],
-				RepoRoot: f[2],
-			})
+		if attrValue(e.Attr, "name") == "go-import" {
+			if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+				imports = append(imports, MetaImport{
+					Prefix:   f[0],
+					VCS:      f[1],
+					RepoRoot: f[2],
+				})
+			}
+		} else if attrValue(e.Attr, "name") == "go-source" {
+			if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 4 {
+				// special handling for gopkg.in as the go-import information does not
+				// contain the repo root, but the go-source information does.
+				if strings.HasPrefix(f[0], "gopkg.in/") {
+					imports = append([]MetaImport{
+						{
+							Prefix:   f[0],
+							VCS:      f[1],
+							RepoRoot: f[2][:strings.Index(f[2], "/tree")],
+						},
+					}, imports...)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
gopkg.in packages are a bit special as they redirect transparently to the github repositories (see https://labix.org/gopkg.in). So we can't depend on `go-import` and have to parse out the `go-source` to get the info we need.

We caught this because https://github.com/go-yaml/yaml is archived and `gopkg.in/yaml.v2` or `gopkg.in/yaml.v3` was NOT showing up in the output of `is-archived` tool.

```
> curl -kvsL gopkg.in/yaml.v1?go-get=1 2>/dev/null

<html>
<head>
<meta name="go-import" content="gopkg.in/yaml.v1 git https://gopkg.in/yaml.v1">
<meta name="go-source" content="gopkg.in/yaml.v1 _ https://github.com/go-yaml/yaml/tree/v1{/dir} https://github.com/go-yaml/yaml/blob/v1{/dir}/{file}#L{line}">
</head>
<body>
go get gopkg.in/yaml.v1
</body>
</html>
```